### PR TITLE
Confluence 7.17.0 - Mysql 8.0.28 - Agent 1.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM openjdk:8-stretch
+FROM openjdk:11-stretch
 
-LABEL maintainer="haxqer <haxqer666@gmail.com>" version="7.6.2"
+LABEL maintainer="haxqer <haxqer666@gmail.com>" version="7.17.0"
 
 ARG ATLASSIAN_PRODUCTION=confluence
 ARG APP_NAME=confluence
-ARG APP_VERSION=7.6.2
-ARG AGENT_VERSION=1.2.2
-ARG MYSQL_DRIVER_VERSION=5.1.48
+ARG APP_VERSION=7.17.0
+ARG AGENT_VERSION=1.3.1
+ARG MYSQL_DRIVER_VERSION=8.0.28
 
 ENV CONFLUENCE_HOME=/var/confluence \
     CONFLUENCE_INSTALL=/opt/confluence \
@@ -19,7 +19,9 @@ ENV CONFLUENCE_HOME=/var/confluence \
 ENV JAVA_OPTS="-javaagent:${AGENT_PATH}/${AGENT_FILENAME} ${JAVA_OPTS}"
 
 RUN mkdir -p ${CONFLUENCE_INSTALL} ${CONFLUENCE_HOME} ${AGENT_PATH} \
-&& curl -o ${AGENT_PATH}/${AGENT_FILENAME}  https://github.com/haxqer/confluence/releases/download/v${AGENT_VERSION}/atlassian-agent.jar -L \
+&& curl -o ${AGENT_PATH}/agent.tar.gz https://gitee.com/pengzhile/atlassian-agent/attach_files/832832/download/atlassian-agent-v${AGENT_VERSION}.tar.gz -L \
+&& tar xzf ${AGENT_PATH}/agent.tar.gz -C ${AGENT_PATH}/ --strip-components 1 \
+&& rm -rf ${AGENT_PATH}/agent.tar.gz \
 && curl -o /tmp/atlassian.tar.gz https://product-downloads.atlassian.com/software/confluence/downloads/atlassian-${APP_NAME}-${APP_VERSION}.tar.gz -L \
 && tar xzf /tmp/atlassian.tar.gz -C /opt/confluence/ --strip-components 1 \
 && rm -f /tmp/atlassian.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-stretch
 
-LABEL maintainer="haxqer <haxqer666@gmail.com>" version="7.17.0"
+LABEL maintainer="axlroden <alex@axlrod.dk>" version="7.17.0"
 
 ARG ATLASSIAN_PRODUCTION=confluence
 ARG APP_NAME=confluence
@@ -29,6 +29,6 @@ RUN mkdir -p ${CONFLUENCE_INSTALL} ${CONFLUENCE_HOME} ${AGENT_PATH} \
 && echo "confluence.home = ${CONFLUENCE_HOME}" > ${CONFLUENCE_INSTALL}/${ATLASSIAN_PRODUCTION}/WEB-INF/classes/confluence-init.properties
 
  WORKDIR $CONFLUENCE_INSTALL
- EXPOSE 8080
+ EXPOSE 8090
 
  ENTRYPOINT ["/opt/confluence/bin/start-confluence.sh", "-fg"]

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ default port: 8090
     docker-compose up -d
 ```
 
-- default db(mysql5.7) configure:
+- default db(mysql 8.0.28) configure:
 
 ```bash
-    driver=mysql5.7+
+    driver=mysql8.0.28
     host=mysql-confluence
     port=3306
     db=confluence
@@ -69,7 +69,7 @@ docker exec confluence-srv java -jar /var/agent/atlassian-agent.jar \
     -s you-server-id-xxxx
 ```
 
-4. Paste your license 
+4. Paste your license
 
 ## Install docker & docker-compose
 - If you use `debian`, just do it.
@@ -82,7 +82,7 @@ docker exec confluence-srv java -jar /var/agent/atlassian-agent.jar \
 
 path : `~/.docker/config.json`
 
-content : 
+content :
 ```
 {
     "proxies": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     image: haxqer/confluence
     container_name: confluence-srv
     environment:
-      - TZ='Asia/Shanghai'
-#      - JVM_MINIMUM_MEMORY=1g
-#      - JVM_MAXIMUM_MEMORY=12g
-#      - JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize=1g -XX:ReservedCodeCacheSize=8g'
+      - TZ='Asia/ShangHai'
+      #- JVM_MINIMUM_MEMORY=1g
+      #- JVM_MAXIMUM_MEMORY=12g
+      #- JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize=1g -XX:ReservedCodeCacheSize=8g'
     depends_on:
       - mysql
     ports:
@@ -19,15 +19,17 @@ services:
       - network-bridge
 
   mysql:
-    image: mysql:5.7
+    image: mysql:8
     container_name: mysql-confluence
     environment:
-      - TZ='Asia/Shanghai'
+      - TZ='Europe/Copenhagen'
       - MYSQL_DATABASE=confluence
       - MYSQL_ROOT_PASSWORD=123456
       - MYSQL_USER=confluence
       - MYSQL_PASSWORD=123123
-    command: ['mysqld', '--character-set-server=utf8', '--collation-server=utf8_bin', '--transaction-isolation=READ-COMMITTED', '--innodb_log_file_size=256M', '--max_allowed_packet=256M']
+    cap_add:
+      - SYS_NICE  # CAP_SYS_NICE
+    command: ['mysqld', '--character-set-server=utf8', '--collation-server=utf8_bin', '--transaction-isolation=READ-COMMITTED', '--innodb_log_file_size=256M', '--max_allowed_packet=256M', '--log_bin_trust_function_creators=1']
     ports:
       - "13306:3306"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3.4'
 services:
   confluence:
-    image: haxqer/confluence
+    image: axlroden/confluence
     container_name: confluence-srv
     environment:
-      - TZ='Asia/ShangHai'
+      - TZ='Europe/Copenhagen'
       #- JVM_MINIMUM_MEMORY=1g
       #- JVM_MAXIMUM_MEMORY=12g
       #- JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize=1g -XX:ReservedCodeCacheSize=8g'
@@ -30,8 +30,7 @@ services:
     cap_add:
       - SYS_NICE  # CAP_SYS_NICE
     command: ['mysqld', '--character-set-server=utf8', '--collation-server=utf8_bin', '--transaction-isolation=READ-COMMITTED', '--innodb_log_file_size=256M', '--max_allowed_packet=256M', '--log_bin_trust_function_creators=1']
-    ports:
-      - "13306:3306"
+
     volumes:
       - ./mysql:/var/lib/mysql
     restart: always


### PR DESCRIPTION
Updated to have support for Confluence 7.17.0 and MySQL 8

This also pulls agent 1.3.1 directly from https://gitee.com/pengzhile/atlassian-agent

This agent could work for all other Atlassian products the same way.